### PR TITLE
Document to quote spaces on windows

### DIFF
--- a/colcon_ros/task/ros.py
+++ b/colcon_ros/task/ros.py
@@ -29,17 +29,15 @@ class RosTask(TaskExtensionPoint):
         parser.add_argument(
             '--ament-cmake-args',
             nargs='*', metavar='*', type=str.lstrip,
-            help="Arbitrary arguments which are passed to all 'ament_cmake' "
-            'packages. Args that start with "-" must be prefixed with a '
-            'space.'
-            '\n\t--ament-cmake-args " -Dvar=val"\n')
+            help="Pass arguments to all 'ament_cmake' packages. Every arg "
+            'starting with a dash must be prefixed by a space,\n'
+            'e.g. --ament-cmake-args " -Dvar=val"')
         parser.add_argument(
             '--catkin-cmake-args',
             nargs='*', metavar='*', type=str.lstrip,
-            help="Arbitrary arguments which are passed to all 'catkin' "
-            'packages. Args that start with "-" must be prefixed with a '
-            'space.'
-            '\n\t--catkin-cmake-args " -Dvar=val"\n')
+            help="Pass arguments to all 'catkin' packages. Every arg starting "
+            'with a dash must be prefixed by a space,\n'
+            'e.g. --catkin-cmake-args " -Dvar=val"')
 
     async def build(self):  # noqa: D102
         args = self.context.args

--- a/colcon_ros/task/ros.py
+++ b/colcon_ros/task/ros.py
@@ -31,18 +31,14 @@ class RosTask(TaskExtensionPoint):
             nargs='*', metavar='*', type=str.lstrip,
             help="Arbitrary arguments which are passed to all 'ament_cmake' "
             'packages. Args that start with "-" must be prefixed with a '
-            'space. If using bash then use'
-            '\n\t--ament-cmake-args \ -Dvar=val\n'
-            'If using Windows cmd then use'
+            'space.'
             '\n\t--ament-cmake-args " -Dvar=val"\n')
         parser.add_argument(
             '--catkin-cmake-args',
             nargs='*', metavar='*', type=str.lstrip,
             help="Arbitrary arguments which are passed to all 'catkin' "
             'packages. Args that start with "-" must be prefixed with a '
-            'space. If using bash then use'
-            '\n\t--catkin-cmake-args \ -Dvar=val\n'
-            'If using Windows cmd then use'
+            'space.'
             '\n\t--catkin-cmake-args " -Dvar=val"\n')
 
     async def build(self):  # noqa: D102

--- a/colcon_ros/task/ros.py
+++ b/colcon_ros/task/ros.py
@@ -30,14 +30,20 @@ class RosTask(TaskExtensionPoint):
             '--ament-cmake-args',
             nargs='*', metavar='*', type=str.lstrip,
             help="Arbitrary arguments which are passed to all 'ament_cmake' "
-            'packages (args which start with a dash must be prefixed with an '
-            'escaped space `\ `, e.g.: `--ament-cmake-args \ -Dvar=val`)')
+            'packages. Args that start with "-" must be prefixed with a '
+            'space. If using bash then use'
+            '\n\t--ament-cmake-args \ -Dvar=val\n'
+            'If using Windows cmd then use'
+            '\n\t--ament-cmake-args " -Dvar=val"\n')
         parser.add_argument(
             '--catkin-cmake-args',
             nargs='*', metavar='*', type=str.lstrip,
             help="Arbitrary arguments which are passed to all 'catkin' "
-            'packages (args which start with a dash must be prefixed with an '
-            'escaped space `\ `, e.g.: `--catkin-cmake-args \ -Dvar=val`)')
+            'packages. Args that start with "-" must be prefixed with a '
+            'space. If using bash then use'
+            '\n\t--catkin-cmake-args \ -Dvar=val\n'
+            'If using Windows cmd then use'
+            '\n\t--catkin-cmake-args " -Dvar=val"\n')
 
     async def build(self):  # noqa: D102
         args = self.context.args


### PR DESCRIPTION
connects to colcon/colcon-cmake#6

The help text now says

```
Arguments for 'ros' packages:
  --ament-cmake-args [* [* ...]]
                        Arbitrary arguments which are passed to all
                        'ament_cmake' packages. Args that start with "-" must
                        be prefixed with a space. If using bash then use
                                --ament-cmake-args \ -Dvar=val
                        If using Windows cmd then use
                                --ament-cmake-args " -Dvar=val"
  --catkin-cmake-args [* [* ...]]
                        Arbitrary arguments which are passed to all 'catkin'
                        packages. Args that start with "-" must be prefixed
                        with a space. If using bash then use
                                --catkin-cmake-args \ -Dvar=val
                        If using Windows cmd then use
                                --catkin-cmake-args " -Dvar=val"
```