### PR TITLE
ignore dry ROS packages

### DIFF
--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -55,6 +55,10 @@ class RosPackageIdentification(
         # parse package manifest and get build type
         pkg, build_type = get_package_with_build_type(str(desc.path))
         if not pkg or not build_type:
+            # if it is not a wet ROS package check for a dry ROS package
+            if (desc.path / 'manifest.xml').exists():
+                # ignore location to avoid being identified as a CMake package
+                raise IgnoreLocationException()
             return
 
         desc.type = 'ros'


### PR DESCRIPTION
This is necessary for ROS 1 devel jobs since some repos (e.g. [moveit](https://github.com/ros-planning/moveit/)) still contain dry packages.

The easiest to reproduce and see the effect of the patch is to invoke `colcon list` on such a repo.