### PR TITLE
fix -D CMAKE_PREFIX_PATH separator

### DIFF
--- a/colcon_ros/task/ros.py
+++ b/colcon_ros/task/ros.py
@@ -78,6 +78,8 @@ class RosTask(TaskExtensionPoint):
             # extend CMAKE_PREFIX_PATH with AMENT_PREFIX_PATH
             ament_prefix_path = os.environ.get('AMENT_PREFIX_PATH')
             if ament_prefix_path:
+                ament_prefix_path = ament_prefix_path.replace(
+                    os.pathsep, ';')
                 if args.cmake_args is None:
                     args.cmake_args = []
                 # check if the CMAKE_PREFIX_PATH is explicitly set
@@ -88,7 +90,7 @@ class RosTask(TaskExtensionPoint):
                     # extend the last existing entry
                     existing = value[len(prefix):]
                     if existing:
-                        existing = os.pathsep + existing
+                        existing = ';' + existing
                     args.cmake_args[i] = \
                         '-DCMAKE_PREFIX_PATH={ament_prefix_path}{existing}' \
                         .format_map(locals())
@@ -97,7 +99,8 @@ class RosTask(TaskExtensionPoint):
                     # otherwise extend the environment variable
                     existing = os.environ.get('CMAKE_PREFIX_PATH', '')
                     if existing:
-                        existing = os.pathsep + existing
+                        existing = ';' + existing.replace(
+                            os.pathsep, ';')
                     args.cmake_args.append(
                         '-DCMAKE_PREFIX_PATH={ament_prefix_path}{existing}'
                         .format_map(locals()))


### PR DESCRIPTION
Follow up of #21.

The value of `-DCMAKE_PREFIX_PATH` must use CMake's list separator `;` rather than the platform specific path separator (which is `:` on e.g. Linux).