### PR TITLE
 add cargo build type support 

### DIFF
--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -160,7 +160,7 @@ def _get_build_type(pkg):
         return None
 
     supported_build_types = (
-        'ament_cmake', 'ament_python', 'catkin', 'cmake', 'cargo')
+        'ament_cmake', 'ament_python', 'cargo', 'catkin', 'cmake')
 
     if build_type not in supported_build_types:
         path = os.path.dirname(pkg.filename)

--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -159,7 +159,10 @@ def _get_build_type(pkg):
             'build type'.format_map(locals()))
         return None
 
-    if build_type not in ('ament_cmake', 'ament_python', 'catkin', 'cmake', 'cargo'):
+    supported_build_types = (
+        'ament_cmake', 'ament_python', 'catkin', 'cmake', 'cargo')
+
+    if build_type not in supported_build_types:
         path = os.path.dirname(pkg.filename)
         logger.debug(
             "ROS package '{pkg.name}' in '{path}' has unknown build "

--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -42,6 +42,7 @@ class RosPackageIdentification(
                 'therefore ROS packages can not be identified')
 
     def identify(self, desc):  # noqa: D102
+
         # ignore packages which have been identified with a different type
         if desc.type is not None and desc.type != 'ros':
             return
@@ -159,7 +160,7 @@ def _get_build_type(pkg):
             'build type'.format_map(locals()))
         return None
 
-    if build_type not in ('ament_cmake', 'ament_python', 'catkin', 'cmake'):
+    if build_type not in ('ament_cmake', 'ament_python', 'catkin', 'cmake', 'cargo'):
         path = os.path.dirname(pkg.filename)
         logger.debug(
             "ROS package '{pkg.name}' in '{path}' has unknown build "

--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -42,7 +42,6 @@ class RosPackageIdentification(
                 'therefore ROS packages can not be identified')
 
     def identify(self, desc):  # noqa: D102
-
         # ignore packages which have been identified with a different type
         if desc.type is not None and desc.type != 'ros':
             return

--- a/colcon_ros/task/ros.py
+++ b/colcon_ros/task/ros.py
@@ -15,6 +15,7 @@ from colcon_core.task import install
 from colcon_core.task import TaskExtensionPoint
 from colcon_core.task.python.build import PythonBuildTask
 from colcon_core.task.python.test import PythonTestTask
+from colcon_cargo.task.cargo.build import CargoBuildTask
 from colcon_ros.package_identification.ros import get_package_with_build_type
 
 logger = colcon_logger.getChild(__name__)
@@ -137,6 +138,20 @@ class RosTask(TaskExtensionPoint):
 
         elif build_type == 'cmake':
             extension = CmakeBuildTask()
+
+        elif build_type == 'cargo':
+            extension = CargoBuildTask()
+            additional_hooks += create_environment_hook(
+                'ament_prefix_path', Path(args.install_base), pkg.name,
+                'AMENT_PREFIX_PATH', '', mode='prepend')
+            # create package marker in ament resource index
+            create_file(
+                args, 'share/ament_index/resource_index/packages/{pkg.name}'
+                .format_map(locals()))
+            # copy / symlink package manifest
+            install(
+                args, 'package.xml', 'share/{pkg.name}/package.xml'
+                .format_map(locals()))
 
         else:
             assert False, 'Unknown build type: ' + build_type

--- a/colcon_ros/task/ros.py
+++ b/colcon_ros/task/ros.py
@@ -13,9 +13,10 @@ from colcon_core.shell import create_environment_hook
 from colcon_core.task import create_file
 from colcon_core.task import install
 from colcon_core.task import TaskExtensionPoint
+from colcon_cargo.task.cargo.build import CargoBuildTask
+from colcon_cargo.task.cargo.test import CargoTestTask
 from colcon_core.task.python.build import PythonBuildTask
 from colcon_core.task.python.test import PythonTestTask
-from colcon_cargo.task.cargo.build import CargoBuildTask
 from colcon_ros.package_identification.ros import get_package_with_build_type
 
 logger = colcon_logger.getChild(__name__)
@@ -200,6 +201,8 @@ class RosTask(TaskExtensionPoint):
             extension = CmakeTestTask()
         elif build_type == 'ament_python':
             extension = PythonTestTask()
+        elif build_type == 'cargo':
+            extension = CargoTestTask()
         else:
             assert False, 'Unknown build type: ' + build_type
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ keywords = colcon
 [options]
 install_requires =
   catkin_pkg
+  colcon-cargo
   colcon-cmake>=0.2.0
   colcon-core>=0.3.1
   # technically not a required dependency but "very common" for ROS 1 users
@@ -34,7 +35,6 @@ install_requires =
   colcon-python-setup-py
   # technically not a required dependency but "very common" for ROS users
   colcon-recursive-crawl
-  colcon-cargo
 packages = find:
 tests_require =
   flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
   colcon-python-setup-py
   # technically not a required dependency but "very common" for ROS users
   colcon-recursive-crawl
+  colcon-cargo
 packages = find:
 tests_require =
   flake8


### PR DESCRIPTION
_cargo_ build type is supported and mimic _ament_python_ behavior.