### PR TITLE
support ROS Python packages using a setup.cfg file

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -1,5 +1,6 @@
 ament
 argcomplete
+cfg
 cmake
 colcon
 fallback


### PR DESCRIPTION
Currently the Python packages must have a `setup.py` file which is handled by `colcon-python-setup-py`. This patch adds support for Python package which specify their meta information in the `setup.cfg` file (like this package does).