### PR TITLE
use new argument to manipulate the environment instead of changing cmake-args

### DIFF
--- a/colcon_ros/task/__init__.py
+++ b/colcon_ros/task/__init__.py
@@ -4,33 +4,14 @@
 import os
 
 
-def extend_cpp_with_app(args):
-    """Extend CMAKE_PREFIX_PATH with AMENT_PREFIX_PATH."""
+def append_app_to_cpp(env):
+    """Append AMENT_PREFIX_PATH to CMAKE_PREFIX_PATH."""
     ament_prefix_path = os.environ.get('AMENT_PREFIX_PATH')
     if ament_prefix_path:
-        ament_prefix_path = ament_prefix_path.replace(
-            os.pathsep, ';')
-        if args.cmake_args is None:
-            args.cmake_args = []
-        # check if the CMAKE_PREFIX_PATH is explicitly set
-        prefix = '-DCMAKE_PREFIX_PATH='
-        for i, value in reversed(list(enumerate(args.cmake_args))):
-            if not value.startswith(prefix):
-                continue
-            # extend the last existing entry
-            existing = value[len(prefix):]
-            if existing:
-                existing = ';' + existing
-            args.cmake_args[i] = \
-                '-DCMAKE_PREFIX_PATH={ament_prefix_path}{existing}' \
-                .format_map(locals())
-            break
-        else:
-            # otherwise extend the environment variable
-            existing = os.environ.get('CMAKE_PREFIX_PATH', '')
-            if existing:
-                existing = ';' + existing.replace(
-                    os.pathsep, ';')
-            args.cmake_args.append(
-                '-DCMAKE_PREFIX_PATH={ament_prefix_path}{existing}'
-                .format_map(locals()))
+        cmake_prefix_path = env.get('CMAKE_PREFIX_PATH')
+        cpp = cmake_prefix_path.split(os.pathsep) if cmake_prefix_path else []
+        app = ament_prefix_path.split(os.pathsep)
+        for p in app:
+            if p not in cpp:
+                cpp.append(p)
+        env['CMAKE_PREFIX_PATH'] = os.pathsep.join(cpp)

--- a/colcon_ros/task/ament_cmake/build.py
+++ b/colcon_ros/task/ament_cmake/build.py
@@ -8,7 +8,7 @@ from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.shell import get_shell_extensions
 from colcon_core.task import TaskExtensionPoint
-from colcon_ros.task import extend_cpp_with_app
+from colcon_ros.task import append_app_to_cpp
 
 logger = colcon_logger.getChild(__name__)
 
@@ -67,6 +67,6 @@ class AmentCmakeBuildTask(TaskExtensionPoint):
                 args.cmake_args = []
             args.cmake_args += args.ament_cmake_args
 
-        extend_cpp_with_app(args)
-
-        return await extension.build(additional_hooks=additional_hooks)
+        return await extension.build(
+            environment_callback=append_app_to_cpp,
+            additional_hooks=additional_hooks)

--- a/colcon_ros/task/cmake/build.py
+++ b/colcon_ros/task/cmake/build.py
@@ -6,7 +6,7 @@ from colcon_cmake.task.cmake.build import CmakeBuildTask as CmakeBuildTask_
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.task import TaskExtensionPoint
-from colcon_ros.task import extend_cpp_with_app
+from colcon_ros.task import append_app_to_cpp
 
 logger = colcon_logger.getChild(__name__)
 
@@ -28,6 +28,4 @@ class CmakeBuildTask(TaskExtensionPoint):
         extension = CmakeBuildTask_()
         extension.set_context(context=self.context)
 
-        extend_cpp_with_app(args)
-
-        return await extension.build()
+        return await extension.build(environment_callback=append_app_to_cpp)


### PR DESCRIPTION
Altering `cmake-args` wasn't a good idea in the first place and when the [CMake build](https://github.com/colcon/colcon-cmake/blob/f4ff4a382153516ddc6071104b61ce9a2125600c/colcon_cmake/task/cmake/build.py#L75) function later retrieves the environment for e.g. an overlay workspace that information isn't being considered in the `extend_cpp_with_app` function`. Since the modified `cmake-args` take precedence over the `CMAKE_PREFIX_PATH` environment variable the resulting environment might be incomplete or misordered.

Requires colcon/colcon-cmake#.