### PR TITLE
remove pycodestyle pinned version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,11 +46,6 @@ tests_require =
   flake8-import-order
   flake8-quotes
   pep8-naming
-  # working around a pkg_resources.ContextualVersionConflict
-  # by installing a specific version of pycodestyle
-  # flake8-import-order depends on pycodestyle without a version range
-  # flake8 depends on a pycodestyle but with a restricted version range
-  pycodestyle==2.3.1
   pyenchant
   pylint
   pytest


### PR DESCRIPTION
With the latest releases of `flake8` and its plugins this pinning is not necessary anymore. It was originally added in #6.