### PR TITLE
add No-Python2 flag to stdeb.cfg to avoid making Python 2 releases by accident

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,5 @@
 [colcon-ros]
+No-Python2:
 Depends3: python3-catkin-pkg-modules, python3-colcon-cmake (>= 0.2.6), python3-colcon-core (>= 0.3.16), python3-colcon-pkg-config, python3-colcon-python-setup-py, python3-colcon-recursive-crawl
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
Same as colcon/colcon-core#165.