### PR TITLE
ensure ROS 2 prefix paths are before ROS 1 prefix paths

### DIFF
--- a/colcon_ros/task/__init__.py
+++ b/colcon_ros/task/__init__.py
@@ -5,8 +5,36 @@ import os
 import warnings
 
 
+def add_app_to_cpp(env):
+    """
+    Add AMENT_PREFIX_PATH to CMAKE_PREFIX_PATH.
+
+    Each ament prefix path is inserted before the first catkin prefix path or
+    at the end if none of the CMake prefix paths has a '.catkin' marker file.
+    """
+    ament_prefix_path = os.environ.get('AMENT_PREFIX_PATH')
+    if ament_prefix_path:
+        cmake_prefix_path = env.get('CMAKE_PREFIX_PATH')
+        cpp = cmake_prefix_path.split(os.pathsep) if cmake_prefix_path else []
+        cpp_has_dot_catkin = [
+            os.path.exists(os.path.join(p, '.catkin')) for p in cpp]
+        app = ament_prefix_path.split(os.pathsep)
+        for p in app:
+            if p not in cpp:
+                try:
+                    index = cpp_has_dot_catkin.index(True)
+                    cpp.insert(index, p)
+                    cpp_has_dot_catkin.insert(index, False)
+                except ValueError:
+                    cpp.append(p)
+        env['CMAKE_PREFIX_PATH'] = os.pathsep.join(cpp)
+
+
 def append_app_to_cpp(env):
     """Append AMENT_PREFIX_PATH to CMAKE_PREFIX_PATH."""
+    warnings.warn(
+        'colcon_ros.task.append_app_to_cpp() will be removed in the future',
+        DeprecationWarning, stacklevel=2)
     ament_prefix_path = os.environ.get('AMENT_PREFIX_PATH')
     if ament_prefix_path:
         cmake_prefix_path = env.get('CMAKE_PREFIX_PATH')

--- a/colcon_ros/task/ament_cmake/build.py
+++ b/colcon_ros/task/ament_cmake/build.py
@@ -8,7 +8,7 @@ from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.shell import get_shell_extensions
 from colcon_core.task import TaskExtensionPoint
-from colcon_ros.task import append_app_to_cpp
+from colcon_ros.task import add_app_to_cpp
 
 logger = colcon_logger.getChild(__name__)
 
@@ -68,5 +68,5 @@ class AmentCmakeBuildTask(TaskExtensionPoint):
             args.cmake_args += args.ament_cmake_args
 
         return await extension.build(
-            environment_callback=append_app_to_cpp,
+            environment_callback=add_app_to_cpp,
             additional_hooks=additional_hooks)

--- a/colcon_ros/task/cmake/build.py
+++ b/colcon_ros/task/cmake/build.py
@@ -6,7 +6,7 @@ from colcon_cmake.task.cmake.build import CmakeBuildTask as CmakeBuildTask_
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.task import TaskExtensionPoint
-from colcon_ros.task import append_app_to_cpp
+from colcon_ros.task import add_app_to_cpp
 
 logger = colcon_logger.getChild(__name__)
 
@@ -28,4 +28,4 @@ class CmakeBuildTask(TaskExtensionPoint):
         extension = CmakeBuildTask_()
         extension.set_context(context=self.context)
 
-        return await extension.build(environment_callback=append_app_to_cpp)
+        return await extension.build(environment_callback=add_app_to_cpp)


### PR DESCRIPTION
Instead of simply concatenating them ROS 2 prefix paths are always inserted *before* ROS 1 prefix paths.

That ensures that ROS 2 packages can be `find_package()`-ed where as ROS 1 packages are discovered using `pkg-config`.