### PR TITLE
Add additional variables to CMake build to help packages detect ROS

### DIFF
--- a/colcon_ros/task/cmake/build.py
+++ b/colcon_ros/task/cmake/build.py
@@ -7,6 +7,8 @@ from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.task import TaskExtensionPoint
 from colcon_ros.task import add_app_to_cpp
+from colcon_core import __version__ as colcon_core_version
+from os import environ
 
 logger = colcon_logger.getChild(__name__)
 
@@ -27,5 +29,14 @@ class CmakeBuildTask(TaskExtensionPoint):
         # reuse CMake build task with additional logic
         extension = CmakeBuildTask_()
         extension.set_context(context=self.context)
+
+        #Add extra CMake variables to help packages detect ROS
+        if self.context.args.cmake_args is None:
+            self.context.args.cmake_args = []
+        self.context.args.cmake_args += ['-DCOLCON_VERSION:STRING=' + str(colcon_core_version)]
+        if 'ROS_VERSION' in environ:
+            self.context.args.cmake_args += ['-DCOLCON_ROS_VERSION:STRING=' + environ['ROS_VERSION']]
+        if 'ROS_DISTRO' in environ:
+            self.context.args.cmake_args += ['-DCOLCON_ROS_DISTRO:STRING=' + environ['ROS_DISTRO']]
 
         return await extension.build(environment_callback=add_app_to_cpp)

--- a/colcon_ros/task/cmake/build.py
+++ b/colcon_ros/task/cmake/build.py
@@ -30,13 +30,18 @@ class CmakeBuildTask(TaskExtensionPoint):
         extension = CmakeBuildTask_()
         extension.set_context(context=self.context)
 
-        #Add extra CMake variables to help packages detect ROS
+        # Add extra CMake variables to help packages detect ROS
         if self.context.args.cmake_args is None:
             self.context.args.cmake_args = []
-        self.context.args.cmake_args += ['-DCOLCON_VERSION:STRING=' + str(colcon_core_version)]
+        self.context.args.cmake_args += ['-D' + 'COLCON_VERSION:STRING='
+                                         + str(colcon_core_version)]
         if 'ROS_VERSION' in environ:
-            self.context.args.cmake_args += ['-DCOLCON_ROS_VERSION:STRING=' + environ['ROS_VERSION']]
+            self.context.args.cmake_args += ['-D'
+                                             + 'COLCON_ROS_VERSION:STRING='
+                                             + environ['ROS_VERSION']]
         if 'ROS_DISTRO' in environ:
-            self.context.args.cmake_args += ['-DCOLCON_ROS_DISTRO:STRING=' + environ['ROS_DISTRO']]
+            self.context.args.cmake_args += ['-D'
+                                             + 'COLCON_ROS_DISTRO:STRING='
+                                             + environ['ROS_DISTRO']]
 
         return await extension.build(environment_callback=add_app_to_cpp)

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -13,6 +13,7 @@ dcmake
 debian
 debinfo
 descs
+distro
 dsetuptools
 github
 https


### PR DESCRIPTION
Currently there is no easy way for CMake packages to detect a ROS build. This pull request adds additional CMake variable args COLCON_VERSION, COLCON_ROS_VERSION, and COLCON_ROS_DISTRO to the cmake command. This will allow packages to detect a ROS build and the ROS version so it can adjust accordingly.

@Levi-Armstrong