### PR TITLE
suppress deprecation warnings from third party code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ zip_safe = true
 [tool:pytest]
 filterwarnings =
     error
+    ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning
+    ignore:the imp module is deprecated in favour of importlib.*:PendingDeprecationWarning
 junit_suite_name = colcon-ros
 
 [options.entry_points]


### PR DESCRIPTION
This patch addresses the failing CI due to the recent release of `pytest` 5.0.

Similar to colcon/colcon-core#200.