### PR TITLE
log a debug message if the package.xml file can't be parsed successfully

### DIFF
--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -175,7 +175,10 @@ def _get_package(path: str):
 
     try:
         pkg = parse_package(path)
-    except (AssertionError, InvalidPackage):
+    except (AssertionError, InvalidPackage) as e:  # noqa: F841
+        logger.debug(
+            "Failed to parse potential ROS package manifest in '{path}': {e}"
+            .format_map(locals()))
         return None
 
     pkg.evaluate_conditions(os.environ)


### PR DESCRIPTION
Since the parsed file might not even be a ROS package manifest I didn't pick a higher log level.