### PR TITLE
readd implicitly installing marker and manifest files but warn about it

### DIFF
--- a/colcon_ros/task/ament_python/build.py
+++ b/colcon_ros/task/ament_python/build.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.shell import create_environment_hook
+from colcon_core.task import create_file
+from colcon_core.task import install
 from colcon_core.task import TaskExtensionPoint
 from colcon_core.task.python.build import PythonBuildTask
 
@@ -33,5 +35,14 @@ class AmentPythonBuildTask(TaskExtensionPoint):
         additional_hooks = create_environment_hook(
             'ament_prefix_path', Path(args.install_base),
             self.context.pkg.name, 'AMENT_PREFIX_PATH', '', mode='prepend')
+        # create package marker in ament resource index
+        create_file(
+            args,
+            'share/ament_index/resource_index/packages/{self.context.pkg.name}'
+            .format_map(locals()))
+        # copy / symlink package manifest
+        install(
+            args, 'package.xml', 'share/{self.context.pkg.name}/package.xml'
+            .format_map(locals()))
 
         return await extension.build(additional_hooks=additional_hooks)

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -31,6 +31,7 @@ plugin
 prepend
 pytest
 pythonpath
+relpath
 rstrip
 rtype
 scspell
@@ -40,6 +41,7 @@ stacklevel
 stdeb
 symlink
 thomas
+todo
 tuples
 unittest
 workspaces


### PR DESCRIPTION
The first commit reverts #74 - to again implicitly install marker and manifest files. Based on the 
Discourse conversation https://discourse.ros.org/t/can-we-chat-about-breaking-changes-in-stable-releases/10689 as well as several other reports.

The second commit changes the logic to only install the files implicitly if the package doesn't already do it explicitly using the `data_files` option. In the case the files are implicitly installed by `colcon-ros` a warning is printed to notify the user that this "magic" will be removed in the future.