### PR TITLE
increase severity of log message for package parse errors from debug to warn

### DIFF
--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -176,7 +176,7 @@ def _get_package(path: str):
     try:
         pkg = parse_package(path)
     except (AssertionError, InvalidPackage) as e:  # noqa: F841
-        logger.debug(
+        logger.warn(
             "Failed to parse potential ROS package manifest in '{path}': {e}"
             .format_map(locals()))
         return None

--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -169,6 +169,7 @@ def _get_package(path: str):
     from catkin_pkg.package import InvalidPackage
     from catkin_pkg.package import package_exists_at
     from catkin_pkg.package import parse_package
+    from catkin_pkg.package import has_ros_schema_reference
 
     if not package_exists_at(path):
         return None
@@ -176,9 +177,17 @@ def _get_package(path: str):
     try:
         pkg = parse_package(path)
     except (AssertionError, InvalidPackage) as e:  # noqa: F841
-        logger.warn(
-            "Failed to parse potential ROS package manifest in '{path}': {e}"
-            .format_map(locals()))
+        if has_ros_schema_reference(path):
+            logger.debug(
+                "Found ROS schema reference in package manifest in '{path}'"
+                .format_map(locals())
+            logger.warn(
+                "Failed to parse ROS package manifest in '{path}': {e}"
+                .format_map(locals()))
+        else:
+            logger.debug(
+                "Failed to parse potential ROS package manifest in '{path}': {e}"
+                .format_map(locals()))
         return None
 
     pkg.evaluate_conditions(os.environ)

--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -186,9 +186,8 @@ def _get_package(path: str):
                 .format_map(locals()))
         else:
             logger.debug(
-                "Failed to parse potential ROS package manifest in" 
-                "'{path}': {e}"
-                .format_map(locals()))
+                'Failed to parse potential ROS package manifest in'
+                "'{path}': {e}".format_map(locals()))
         return None
 
     pkg.evaluate_conditions(os.environ)

--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -180,7 +180,7 @@ def _get_package(path: str):
         if has_ros_schema_reference(path):
             logger.debug(
                 "Found ROS schema reference in package manifest in '{path}'"
-                .format_map(locals())
+                .format_map(locals()))
             logger.warn(
                 "Failed to parse ROS package manifest in '{path}': {e}"
                 .format_map(locals()))

--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -166,10 +166,10 @@ def get_package_with_build_type(path: str):
 
 def _get_package(path: str):
     """Get the ROS package for the given path."""
+    from catkin_pkg.package import has_ros_schema_reference
     from catkin_pkg.package import InvalidPackage
     from catkin_pkg.package import package_exists_at
     from catkin_pkg.package import parse_package
-    from catkin_pkg.package import has_ros_schema_reference
 
     if not package_exists_at(path):
         return None

--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -186,7 +186,8 @@ def _get_package(path: str):
                 .format_map(locals()))
         else:
             logger.debug(
-                "Failed to parse potential ROS package manifest in '{path}': {e}"
+                "Failed to parse potential ROS package manifest in" 
+                "'{path}': {e}"
                 .format_map(locals()))
         return None
 

--- a/debian/patches/setup.cfg.patch
+++ b/debian/patches/setup.cfg.patch
@@ -12,12 +12,12 @@ Author: Dirk Thomas <web@dirk-thomas.net>
  
  [options]
  install_requires = 
--	catkin_pkg
+-	catkin_pkg>=0.4.14
 +	# to avoid conflicts with ROS 1 this Debian package only depends on
 +	# python3-catkin-pkg-modules and not python3-catkin-pkg
 +	# listing it here but not installing it in the Debian package
 +	# would result in a runtime error by pkg_resources
-+	# catkin_pkg
++	# catkin_pkg>=0.4.14
  	colcon-cmake>=0.2.6
  	colcon-core>=0.3.18
  	colcon-pkg-config

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  catkin_pkg
+  catkin_pkg>=0.4.14
   colcon-cmake>=0.2.6
   colcon-core>=0.3.18
   # technically not a required dependency but "very common" for ROS 1 users

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-ros]
 No-Python2:
-Depends3: python3-catkin-pkg-modules, python3-colcon-cmake (>= 0.2.6), python3-colcon-core (>= 0.3.18), python3-colcon-pkg-config, python3-colcon-python-setup-py, python3-colcon-recursive-crawl
+Depends3: python3-catkin-pkg-modules (>= 0.4.14), python3-colcon-cmake (>= 0.2.6), python3-colcon-core (>= 0.3.18), python3-colcon-pkg-config, python3-colcon-python-setup-py, python3-colcon-recursive-crawl
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
I would suggest this should be at least a warning. Being only debug, will make it hard for beginners to find the correct log message in the log file. It took me a long time to figure out why my package wouldn't compile.