### PR TITLE
check that no arguments are passed to the setup() function in setup.py

### DIFF
--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -10,6 +10,7 @@ from colcon_core.package_identification import logger
 from colcon_core.package_identification \
     import PackageIdentificationExtensionPoint
 from colcon_core.package_identification.python import get_configuration
+from colcon_core.package_identification.python import is_reading_cfg_sufficient
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.plugin_system import SkipExtensionException
 from colcon_python_setup_py.package_identification.python_setup_py \
@@ -110,15 +111,16 @@ class RosPackageIdentification(
             for _ in (1, ):
                 # try to get information from setup.cfg file
                 if setup_cfg.is_file():
-                    config = get_configuration(setup_cfg)
-                    name = config.get('metadata', {}).get('name')
-                    if name:
-                        options = config.get('options', {})
+                    if is_reading_cfg_sufficient(setup_py):
+                        config = get_configuration(setup_cfg)
+                        name = config.get('metadata', {}).get('name')
+                        if name:
+                            options = config.get('options', {})
 
-                        def getter(env):
-                            nonlocal options
-                            return options
-                        break
+                            def getter(env):
+                                nonlocal options
+                                return options
+                            break
             else:
                 # use information from setup.py file
 

--- a/debian/patches/setup.cfg.patch
+++ b/debian/patches/setup.cfg.patch
@@ -19,5 +19,5 @@ Author: Dirk Thomas <web@dirk-thomas.net>
 +	# would result in a runtime error by pkg_resources
 +	# catkin_pkg>=0.4.14
  	colcon-cmake>=0.2.6
- 	colcon-core>=0.3.18
+ 	colcon-core>=0.4.3
  	colcon-pkg-config

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ keywords = colcon
 install_requires =
   catkin_pkg>=0.4.14
   colcon-cmake>=0.2.6
-  colcon-core>=0.3.18
+  colcon-core>=0.4.3
   # technically not a required dependency but "very common" for ROS 1 users
   colcon-pkg-config
   colcon-python-setup-py

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-ros]
 No-Python2:
-Depends3: python3-catkin-pkg-modules (>= 0.4.14), python3-colcon-cmake (>= 0.2.6), python3-colcon-core (>= 0.3.18), python3-colcon-pkg-config, python3-colcon-python-setup-py, python3-colcon-recursive-crawl
+Depends3: python3-catkin-pkg-modules (>= 0.4.14), python3-colcon-cmake (>= 0.2.6), python3-colcon-core (>= 0.4.3), python3-colcon-pkg-config, python3-colcon-python-setup-py, python3-colcon-recursive-crawl
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
Fixes #65. Depends on colcon/colcon-core#251. Needs a version dependency bump as soon as the dependency has been released.