### PR TITLE
Fix the variable usage for CATKIN_ENV_HOOK_WORKSPACE

### DIFF
--- a/colcon_ros/task/catkin/build.py
+++ b/colcon_ros/task/catkin/build.py
@@ -98,12 +98,20 @@ class CatkinBuildTask(TaskExtensionPoint):
                 try:
                     # try to set CATKIN_ENV_HOOK_WORKSPACE explicitly before
                     # sourcing these hooks
-                    additional_hooks.append(
-                        shell_extension.create_hook_set_value(
-                            'catkin_env_hook_workspace',
-                            Path(args.install_base), self.context.pkg.name,
-                            'CATKIN_ENV_HOOK_WORKSPACE',
-                            '$COLCON_CURRENT_PREFIX'))
+                    if sys.platform == 'win32':
+                        additional_hooks.append(
+                            shell_extension.create_hook_set_value(
+                                'catkin_env_hook_workspace',
+                                Path(args.install_base), self.context.pkg.name,
+                                'CATKIN_ENV_HOOK_WORKSPACE',
+                                '%COLCON_CURRENT_PREFIX%'))
+                    else:
+                        additional_hooks.append(
+                            shell_extension.create_hook_set_value(
+                                'catkin_env_hook_workspace',
+                                Path(args.install_base), self.context.pkg.name,
+                                'CATKIN_ENV_HOOK_WORKSPACE',
+                                '$COLCON_CURRENT_PREFIX'))
                 except NotImplementedError:
                     # since not all shell extensions might implement this
                     pass

--- a/colcon_ros/task/catkin/build.py
+++ b/colcon_ros/task/catkin/build.py
@@ -3,6 +3,7 @@
 
 from collections import OrderedDict
 import os
+import sys
 from pathlib import Path
 
 from colcon_cmake.task.cmake.build import CmakeBuildTask


### PR DESCRIPTION
This was manifesting when I tried to build ROS1 packages (I am using `colcon` to build `noetic` distro JFYI). And in my case, when `colcon` builds `ros_environment`, I saw `catkin_env_hook_workspace.bat` was generated in the install space and it has the following content:

```bat
:: generated from colcon_core/shell/template/hook_set_value.bat.em
@echo off

set "CATKIN_ENV_HOOK_WORKSPACE=$COLCON_CURRENT_PREFIX"
```

And subsequently, `CATKIN_ENV_HOOK_WORKSPACE` gets passed to `catkin` `env-hook`, for example, `1.ros_etc_dir.bat`, and the hook generated variable with wrong substitute:

```cmd
C:\>set ROS
ROS_DISTRO=noetic
ROS_ETC_DIR=$COLCON_CURRENT_PREFIX/etc/ros
ROS_MASTER_URI=http://localhost:11311
ROS_PACKAGE_PATH=c:\opt\ros\noetic\x64\share
ROS_PYTHON_VERSION=3
ROS_ROOT=$COLCON_CURRENT_PREFIX/share/ros
ROS_VERSION=1
```

I think my solution may not be an elegant one, but I just wanted to surface where the issue comes from. Any feedback is welcome.