### PR TITLE
update PYTHONPATH for catkin packages with Python 3

### DIFF
--- a/colcon_ros/task/catkin/__init__.py
+++ b/colcon_ros/task/catkin/__init__.py
@@ -1,32 +1,35 @@
 # Copyright 2016-2019 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
-import os
-
+from colcon_cmake.task.cmake import get_variable_from_cmake_cache
 from colcon_core.logging import colcon_logger
 from colcon_core.shell import create_environment_hook
 
 logger = colcon_logger.getChild(__name__)
 
 
-def create_pythonpath_environment_hook(basepath, pkg_name):
+def create_pythonpath_environment_hook(build_base, install_base, pkg_name):
     """
     Create a hook script for each primary shell to prepend to the PYTHONPATH.
 
-    :param Path basepath: The path of the prefix
+    :param str build_base: The path of the build directory
+    :param Path install_base: The path of the install prefix
     :param str pkg_name: The package name
     :returns: The relative paths to the created hook scripts
     :rtype: list
     """
     hooks = []
-    # prepend Python 2 specific path to PYTHONPATH if it exists
-    if os.environ.get('ROS_PYTHON_VERSION', '2') == '2':
-        for subdirectory in ('dist-packages', 'site-packages'):
-            python_path = basepath / 'lib' / 'python2.7' / subdirectory
-            logger.log(1, "checking '%s'" % python_path)
-            if python_path.exists():
-                rel_python_path = python_path.relative_to(basepath)
-                hooks += create_environment_hook(
-                    'python2path', basepath, pkg_name,
-                    'PYTHONPATH', str(rel_python_path), mode='prepend')
+    # catkin packages might use `--install-layout deb`
+    # therefore getting the used install directory from the CMake cache
+    # since it might not match distutils.sysconfig.get_python_lib()
+    rel_python_path = get_variable_from_cmake_cache(
+        build_base, 'PYTHON_INSTALL_DIR')
+    # prepend Python specific path to PYTHONPATH if it exists
+    if rel_python_path:
+        abs_python_path = install_base / rel_python_path
+        logger.log(1, "checking '%s'" % abs_python_path)
+        if abs_python_path.exists():
+            hooks += create_environment_hook(
+                'catkin_pythonpath', install_base, pkg_name,
+                'PYTHONPATH', rel_python_path, mode='prepend')
     return hooks

--- a/colcon_ros/task/catkin/build.py
+++ b/colcon_ros/task/catkin/build.py
@@ -78,7 +78,7 @@ class CatkinBuildTask(TaskExtensionPoint):
             'ros_package_path', Path(args.install_base), self.context.pkg.name,
             'ROS_PACKAGE_PATH', 'share', mode='prepend')
         additional_hooks += create_pythonpath_environment_hook(
-            Path(args.install_base), self.context.pkg.name)
+            args.build_base, Path(args.install_base), self.context.pkg.name)
         additional_hooks += create_pkg_config_path_environment_hooks(
             Path(args.install_base), self.context.pkg.name)
 

--- a/colcon_ros/task/catkin/test.py
+++ b/colcon_ros/task/catkin/test.py
@@ -39,7 +39,8 @@ class CatkinTestTask(TaskExtensionPoint):
             self.context.pkg.name,
             'ROS_PACKAGE_PATH', args.path, mode='prepend')
         additional_hooks += create_pythonpath_environment_hook(
-            Path(args.build_base) / 'devel', self.context.pkg.name)
+            args.build_base, Path(args.build_base) / 'devel',
+            self.context.pkg.name)
 
         # generate the necessary setup files for the devel space
         create_environment_scripts_only(

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -40,6 +40,7 @@ setuptools
 stacklevel
 stdeb
 symlink
+sysconfig
 thomas
 todo
 tuples


### PR DESCRIPTION
Replacing the Python 2 specific hard coded path with an approach which reads the `PYTHON_INSTALL_DIR` from the CMake cache and works for Python 2 as well as 3.

This makes it work to build ROS 1 Noetic which uses Python 3.