### PR TITLE
use improved Python package identification

### DIFF
--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -14,7 +14,7 @@ from colcon_core.package_identification.python import is_reading_cfg_sufficient
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.plugin_system import SkipExtensionException
 from colcon_python_setup_py.package_identification.python_setup_py \
-    import get_setup_arguments_with_context
+    import get_setup_information
 
 
 # mapping paths to tuples containing the ROS package and its build type
@@ -126,8 +126,8 @@ class RosPackageIdentification(
 
                 def getter(env):  # noqa: F811
                     nonlocal desc
-                    return get_setup_arguments_with_context(
-                        str(desc.path / 'setup.py'), env)
+                    return get_setup_information(
+                        desc.path / 'setup.py', env=env)
 
             desc.metadata['get_python_setup_options'] = getter
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
   colcon-core>=0.5.3
   # technically not a required dependency but "very common" for ROS 1 users
   colcon-pkg-config
-  colcon-python-setup-py
+  colcon-python-setup-py>=0.2.4
   # technically not a required dependency but "very common" for ROS users
   colcon-recursive-crawl
 packages = find:

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-ros]
 No-Python2:
-Depends3: python3-catkin-pkg-modules (>= 0.4.14), python3-colcon-cmake (>= 0.2.6), python3-colcon-core (>= 0.5.3), python3-colcon-pkg-config, python3-colcon-python-setup-py, python3-colcon-recursive-crawl
+Depends3: python3-catkin-pkg-modules (>= 0.4.14), python3-colcon-cmake (>= 0.2.6), python3-colcon-core (>= 0.5.3), python3-colcon-pkg-config, python3-colcon-python-setup-py (>= 0.2.4), python3-colcon-recursive-crawl
 Suite: xenial bionic focal stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
Alternative to #86 using colcon/colcon-python-setup-py#30. Needs a version dependency bump as soon as the dependency has been released.