### PR TITLE
Ensure data_files is not None.

### DIFF
--- a/colcon_ros/task/ament_python/build.py
+++ b/colcon_ros/task/ament_python/build.py
@@ -52,7 +52,8 @@ class AmentPythonBuildTask(TaskExtensionPoint):
 
         # check if the package index and manifest are being installed
         setup_py_data_files = []
-        if 'data_files' in setup_py_data and setup_py_data['data_files'] is not None:
+        if 'data_files' in setup_py_data and \
+                setup_py_data['data_files'] is not None:
             setup_py_data_files = setup_py_data['data_files']
         data_files = get_data_files_mapping(setup_py_data_files)
 

--- a/colcon_ros/task/ament_python/build.py
+++ b/colcon_ros/task/ament_python/build.py
@@ -51,8 +51,11 @@ class AmentPythonBuildTask(TaskExtensionPoint):
         setup_py_data = get_setup_data(self.context.pkg, env)
 
         # check if the package index and manifest are being installed
-        data_files = get_data_files_mapping(
-            setup_py_data.get('data_files', []))
+        setup_py_data_files = []
+        if 'data_files' in setup_py_data and setup_py_data['data_files'] is not None:
+            setup_py_data_files = setup_py_data['data_files']
+        data_files = get_data_files_mapping(setup_py_data_files)
+
         installs_package_index = False
         installs_package_manifest = False
 

--- a/colcon_ros/task/ament_python/build.py
+++ b/colcon_ros/task/ament_python/build.py
@@ -51,12 +51,8 @@ class AmentPythonBuildTask(TaskExtensionPoint):
         setup_py_data = get_setup_data(self.context.pkg, env)
 
         # check if the package index and manifest are being installed
-        setup_py_data_files = []
-        if 'data_files' in setup_py_data and \
-                setup_py_data['data_files'] is not None:
-            setup_py_data_files = setup_py_data['data_files']
-        data_files = get_data_files_mapping(setup_py_data_files)
-
+        data_files = get_data_files_mapping(
+            setup_py_data.get('data_files', []) or [])
         installs_package_index = False
         installs_package_manifest = False
 


### PR DESCRIPTION
The implementation of setup_py_data includes a key for 'data_files' with
a value of None if the attribute is not specified.
As a result, `setup_py_data.get('data_files', [])` can return `None` if
no data_files are specified.

When data_files is none it actually triggers a failure in colcon-core's
get_data_files_mapping function:

    Traceback (most recent call last):
      File
      "/home/jenkins-agent/workspace/ci_linux/venv/lib/python3.6/site-packages/colcon_core/executor/__init__.py", line 91, in __call__
        rc = await self.task(*args, **kwargs)
      File
       "/home/jenkins-agent/workspace/ci_linux/venv/lib/python3.6/site-packages/colcon_core/task/__init__.py", line 92, in __call__
        return await task_method(*args, **kwargs)
      File
       "/home/jenkins-agent/workspace/ci_linux/venv/lib/python3.6/site-packages/colcon_ros/task/ament_python/build.py", line 55, in build
        setup_py_data.get('data_files', []))
      File
       "/home/jenkins-agent/workspace/ci_linux/venv/lib/python3.6/site-packages/colcon_core/task/python/__init__.py", line 34, in get_data_files_mapping
        for data_file in data_files:
    TypeError: 'NoneType' object is not iterable

An additional PR may be desired there to defensibly check for None
before iterating but I figured I'd start here.