### PR TITLE
reduce help message for --ament/catkin-cmake-args

### DIFF
--- a/colcon_ros/task/ament_cmake/build.py
+++ b/colcon_ros/task/ament_cmake/build.py
@@ -25,8 +25,7 @@ class AmentCmakeBuildTask(TaskExtensionPoint):
             '--ament-cmake-args',
             nargs='*', metavar='*', type=str.lstrip,
             help="Pass arguments to 'ament_cmake' packages. "
-            'Arguments matching other options must be prefixed by a space,\n'
-            'e.g. --ament-cmake-args " --help"')
+            'Arguments matching other options must be prefixed by a space')
 
     async def build(self):  # noqa: D102
         args = self.context.args

--- a/colcon_ros/task/catkin/build.py
+++ b/colcon_ros/task/catkin/build.py
@@ -30,8 +30,7 @@ class CatkinBuildTask(TaskExtensionPoint):
             '--catkin-cmake-args',
             nargs='*', metavar='*', type=str.lstrip,
             help="Pass arguments to 'catkin' packages. "
-            'Arguments matching other options must be prefixed by a space,\n'
-            'e.g. --catkin-cmake-args " --help"')
+            'Arguments matching other options must be prefixed by a space')
         parser.add_argument(
             '--catkin-skip-building-tests',
             action='store_true',


### PR DESCRIPTION
Partially addresses colcon/colcon-cmake#70.

Since ament/cmake CMake args are not different than the standard CMake the example with `--help` doesn't make much sense.

Instead colcon/colcon-cmake#72 provides the additional context.