### PR TITLE
skip redundant environment script generation

### DIFF
--- a/colcon_ros/task/cmake/build.py
+++ b/colcon_ros/task/cmake/build.py
@@ -31,7 +31,8 @@ class CmakeBuildTask(TaskExtensionPoint):
         extension = CmakeBuildTask_()
         extension.set_context(context=self.context)
 
-        rc = await extension.build(environment_callback=add_app_to_cpp)
+        rc = await extension.build(
+            skip_hook_creation=True, environment_callback=add_app_to_cpp)
 
         additional_hooks = create_pkg_config_path_environment_hooks(
             Path(args.install_base), self.context.pkg.name)


### PR DESCRIPTION
Since they are being generated a few lines below: https://github.com/colcon/colcon-ros/blob/b35bc8550b11578646c74e90c933fdd899cc5162/colcon_ros/task/cmake/build.py#L39-L40