### PR TITLE
Support catkin symlink-install

### DIFF
--- a/colcon_ros/task/catkin/build.py
+++ b/colcon_ros/task/catkin/build.py
@@ -58,6 +58,8 @@ class CatkinBuildTask(TaskExtensionPoint):
             args.cmake_args.append(
                 '-DCATKIN_TEST_RESULTS_DIR=' +
                 os.path.dirname(args.test_result_base))
+        if args.symlink_install:
+            args.cmake_args.append('-DCATKIN_SYMLINK_INSTALL=ON')
         if args.catkin_cmake_args:
             args.cmake_args += args.catkin_cmake_args
 


### PR DESCRIPTION
## Overview

This PR adds `colcon build --symlink-install` support for `catkin`.

## Problem

Currently, `--symlink-install` is not handled for catkin, so it doesn't work.

## Solution

I added `-DCATKIN_SYMLINK_INSTALL=ON` if `--symlink-install` is specified.
https://github.com/colcon/colcon-ros/commit/c0729650ea0400805d6ef98e34761dc7ee2d76d6#diff-e7857422a7528e2f883dd0de18b0e30dR61-R62

This is almost the same way as `ament-cmake`.
https://github.com/colcon/colcon-ros/blob/master/colcon_ros/task/ament_cmake/build.py#L60-L63

## How to test

```sh-session
###################################
##### Launch docker container #####
###################################
$ docker run --rm -it osrf/ros:melodic-desktop-full

##################################################
##### Check result with this patch (working) #####
##################################################
# apt update && apt install -y python3-colcon-common-extensions python3-pip
# pip3 install git+https://github.com/kenji-miyake/colcon-ros.git@support-catkin-symlink-install
# mkdir -p ~/colcon_ws/src
# cd ~/colcon_ws/src
# git clone https://github.com/ros/ros_tutorials.git --depth 1 -b melodic-devel
# cd ~/colcon_ws
# colcon build --symlink-install --packages-up-to rospy_tutorials

# ls -l ~/colcon_ws/install/rospy_tutorials/share/rospy_tutorials/001_talker_listener/
total 24
lrwxrwxrwx 1 root root 76 Jun 29 15:01 README -> /root/colcon_ws/src/ros_tutorials/rospy_tutorials/001_talker_listener/README
lrwxrwxrwx 1 root root 76 Jun 29 15:01 listener -> /root/colcon_ws/build/rospy_tutorials/catkin_generated/installspace/listener
lrwxrwxrwx 1 root root 79 Jun 29 15:01 listener.py -> /root/colcon_ws/build/rospy_tutorials/catkin_generated/installspace/listener.py
lrwxrwxrwx 1 root root 74 Jun 29 15:01 talker -> /root/colcon_ws/build/rospy_tutorials/catkin_generated/installspace/talker
lrwxrwxrwx 1 root root 77 Jun 29 15:01 talker.py -> /root/colcon_ws/build/rospy_tutorials/catkin_generated/installspace/talker.py
lrwxrwxrwx 1 root root 92 Jun 29 15:01 talker_listener.launch -> /root/colcon_ws/src/ros_tutorials/rospy_tutorials/001_talker_listener/talker_listener.launch

#########################################################
##### Check result without this patch (not working) #####
#########################################################
# pip3 uninstall -y colcon-ros
# cd ~/colcon_ws
# rm -rf build/ install/ log/
# colcon build --symlink-install --packages-up-to rospy_tutorials

# ls -l ~/colcon_ws/install/rospy_tutorials/share/rospy_tutorials/001_talker_listener/
total 24
-rw-r--r-- 1 root root  157 Jun 29 14:53 README
-rwxr-xr-x 1 root root 2407 Jun 29 14:53 listener
-rwxr-xr-x 1 root root 2407 Jun 29 14:53 listener.py
-rwxr-xr-x 1 root root 2218 Jun 29 14:53 talker
-rwxr-xr-x 1 root root 2218 Jun 29 14:53 talker.py
-rw-r--r-- 1 root root  181 Jun 29 14:53 talker_listener.launch
```