### PR TITLE
Suppress blind except flake8 error

### DIFF
--- a/colcon_ros/task/ament_cmake/build.py
+++ b/colcon_ros/task/ament_cmake/build.py
@@ -63,7 +63,7 @@ class AmentCmakeBuildTask(TaskExtensionPoint):
         # if the build has failed getting targets might not be possible
         try:
             has_install_target = await has_target(args.build_base, 'install')
-        except Exception:
+        except Exception:  # noqa: B902
             if not rc:
                 raise
             has_install_target = False

--- a/colcon_ros/task/catkin/build.py
+++ b/colcon_ros/task/catkin/build.py
@@ -78,7 +78,7 @@ class CatkinBuildTask(TaskExtensionPoint):
         # if the build has failed getting targets might not be possible
         try:
             has_install_target = await has_target(args.build_base, 'install')
-        except Exception:
+        except Exception:  # noqa: B902
             if not rc:
                 raise
             has_install_target = False

--- a/colcon_ros/task/cmake/build.py
+++ b/colcon_ros/task/cmake/build.py
@@ -38,7 +38,7 @@ class CmakeBuildTask(TaskExtensionPoint):
         # if the build has failed getting targets might not be possible
         try:
             has_install_target = await has_target(args.build_base, 'install')
-        except Exception:
+        except Exception:  # noqa: B902
             if not rc:
                 raise
             has_install_target = False


### PR DESCRIPTION
Alternatively, we could throw a known, possibly custom, type from colcon_cmake
and catch it here.
For now, suppressing the linter error seems much easier.