### PR TITLE
Ignore CATKIN_IGNORE paths only when build_type is catkin (same for AMENT_IGNORE)

### DIFF
--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -49,12 +49,6 @@ class RosPackageIdentification(
         if desc.type is not None and desc.type != 'ros':
             return
 
-        # skip paths with an ignore marker file
-        if (desc.path / 'CATKIN_IGNORE').exists():
-            raise IgnoreLocationException()
-        if (desc.path / 'AMENT_IGNORE').exists():
-            raise IgnoreLocationException()
-
         # parse package manifest and get build type
         pkg, build_type = get_package_with_build_type(str(desc.path))
         if not pkg or not build_type:
@@ -63,6 +57,12 @@ class RosPackageIdentification(
                 # ignore location to avoid being identified as a CMake package
                 raise IgnoreLocationException()
             return
+
+        # skip paths with an ignore marker file
+        if build_type.startswith('catkin') and (desc.path / 'CATKIN_IGNORE').exists():
+            raise IgnoreLocationException()
+        if build_type.startswith('ament') and (desc.path / 'AMENT_IGNORE').exists():
+            raise IgnoreLocationException()
 
         # for Python build types ensure that a setup.py file exists
         if build_type == 'ament_python':


### PR DESCRIPTION
My use case: I have a shared source space in which both ROS1 and ROS2 packages reside (the migration to ROS2 is ongoing). Now I want to build the ROS1 packages using catkin_tools, same as before, and the ROS2 packages using colcon. To do this, I place CATKIN_IGNORE files in the ROS2 packages, and COLCON_IGNORE files in the ROS1 packages.

Problem: colcon-ros ignores the ROS2 packages due to an existing CATKIN_IGNORE.

I think colcon should ignore ROS2 packages only when there is a COLCON_IGNORE file present (or AMENT_IGNORE), and respect CATKIN_IGNORE only when the build_type is catkin, as indicated by the package.xml. This PR implements this behavior.