### PR TITLE
Move ament_python metadata extraction to augmentation module

### DIFF
--- a/colcon_ros/package_augmentation/ros_ament_python.py
+++ b/colcon_ros/package_augmentation/ros_ament_python.py
@@ -1,0 +1,60 @@
+# Copyright 2016-2019 Dirk Thomas
+# Licensed under the Apache License, Version 2.0
+
+from colcon_core.package_augmentation import PackageAugmentationExtensionPoint
+from colcon_core.package_identification.python import get_configuration
+from colcon_core.package_identification.python import is_reading_cfg_sufficient
+from colcon_core.plugin_system import satisfies_version
+from colcon_python_setup_py.package_identification.python_setup_py \
+    import get_setup_information
+
+
+class RosAmentPythonPackageAugmentation(PackageAugmentationExtensionPoint):
+    """Augment ament_python packages with information form setup files."""
+
+    # the priority needs to be higher than the extensions augmenting packages
+    # using the setup.py/setup.cfg files
+    PRIORITY = 150
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(
+            PackageAugmentationExtensionPoint.EXTENSION_POINT_VERSION,
+            '^1.0')
+
+    def augment_package(  # noqa: D102
+        self, desc, *, additional_argument_names=None
+    ):
+        if desc.type != 'ros.ament_python':
+            return
+
+        if 'get_python_setup_options' in desc.metadata:
+            return
+
+        setup_py = desc.path / 'setup.py'
+        if not setup_py.is_file():
+            return
+
+        setup_cfg = desc.path / 'setup.cfg'
+        for _ in (1, ):
+            # try to get information from setup.cfg file
+            if setup_cfg.is_file():
+                if is_reading_cfg_sufficient(setup_py):
+                    config = get_configuration(setup_cfg)
+                    name = config.get('metadata', {}).get('name')
+                    if name:
+                        options = config.get('options', {})
+
+                        def getter(env):
+                            nonlocal options
+                            return options
+                        break
+        else:
+            # use information from setup.py file
+
+            def getter(env):  # noqa: F811
+                nonlocal desc
+                return get_setup_information(
+                    desc.path / 'setup.py', env=env)
+
+        desc.metadata['get_python_setup_options'] = getter

--- a/colcon_ros/package_augmentation/ros_ament_python.py
+++ b/colcon_ros/package_augmentation/ros_ament_python.py
@@ -10,7 +10,7 @@ from colcon_python_setup_py.package_identification.python_setup_py \
 
 
 class RosAmentPythonPackageAugmentation(PackageAugmentationExtensionPoint):
-    """Augment ament_python packages with information form setup files."""
+    """Augment ament_python packages with information from setup files."""
 
     # the priority needs to be higher than the extensions augmenting packages
     # using the setup.py/setup.cfg files

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,6 +70,7 @@ colcon_argcomplete.argcomplete_completer =
     catkin_cmake_args = colcon_ros.argcomplete_completer.catkin_cmake_args:CatkinCmakeArgcompleteCompleter
 colcon_core.package_augmentation =
     ros = colcon_ros.package_identification.ros:RosPackageIdentification
+    ros_ament_python = colcon_ros.package_augmentation.ros_ament_python:RosAmentPythonPackageAugmentation
 colcon_core.package_identification =
     ignore_ament_install = colcon_ros.package_identification.ignore:IgnorePackageIdentification
     ros = colcon_ros.package_identification.ros:RosPackageIdentification


### PR DESCRIPTION
This will give other extensions and users finer control over ROS package identification, and aligns this extension better with the same process as is performed in [colcon-core]( https://github.com/colcon/colcon-core/blob/c4c622f4e961aaa9fb40c91eed5d02054992da8b/colcon_core/package_augmentation/python.py#L60
) and [colcon-python-setup-py](https://github.com/colcon/colcon-python-setup-py/blob/496290a52b4e979b26d4f6390020b4db8de4f197/colcon_python_setup_py/package_augmentation/python_setup_py.py#L53).

The only change in behavior during typical use should be that ROS packages which declare their `build_type` as `ament_python` but which contain no `setup.py` files will no longer be skipped with an error message. Instead, the package will fail to build with a message stating that the `setup.py` could not be found:
```
/usr/bin/python3: can't open file 'src/foo/setup.py': [Errno 2] No such file or directory
```

The change in behavior also aligns better with ROS cmake and ament_cmake projects, where a missing `CMakeLists.txt`, though a critical omission, does not affect the ability to identify the project and will instead result in a build failure.