### PR TITLE
support ros.meson packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
   catkin_pkg>=0.4.14
   colcon-cmake>=0.2.6
   colcon-core>=0.7.0
+  colcon-meson
   # technically not a required dependency but "very common" for ROS 1 users
   colcon-pkg-config
   colcon-python-setup-py>=0.2.4
@@ -84,6 +85,7 @@ colcon_core.task.build =
     ros.ament_python = colcon_ros.task.ament_python.build:AmentPythonBuildTask
     ros.catkin = colcon_ros.task.catkin.build:CatkinBuildTask
     ros.cmake = colcon_ros.task.cmake.build:CmakeBuildTask
+    ros.meson = colcon_meson.build:MesonBuildTask
 colcon_core.task.test =
     ros.ament_cmake = colcon_ros.task.ament_cmake.test:AmentCmakeTestTask
     ros.ament_python = colcon_ros.task.ament_python.test:AmentPythonTestTask


### PR DESCRIPTION
Packages of plain type `meson` are already supported by [`colcon-meson`](https://github.com/colcon/colcon-meson). This adds support for meson packages with a `package.xml`, which are identified as `ros.meson`, by simply forwarding the `ros.meson` task extension to the `meson` task extension.

Without this, meson packages with a `package.xml` for binary dependency resolution will be ignored and the warning:
```
WARNING:colcon.colcon_core.verb:No task extension to 'build' a 'ros.meson' package
```
will be shown.

Note: This does not add support for building ROS nodes via meson. While finding and linking the core ROS libraries will probably be possible, none of the CMake macros have been ported.

I am not sure why there is even a distinction between `cmake` vs `ros.cmake` and `meson` vs `ros.meson`. I believe those `ros.` prefixed types could as well be handled via the `colcon-cmake` and `colcon-meson` extensions. The `colcon_ros.task.cmake.build:CmakeBuildTask` looks rather trivial.

Can someone explain why plain CMake packages with a `package.xml` have to be build by `colcon-ros` instead of `colcon-cmake`?