### PR TITLE
Move dependency and version processing to augmentation

### DIFF
--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -67,6 +67,16 @@ class RosPackageIdentification(
         if desc.name is None:
             desc.name = pkg.name
 
+    def augment_package(  # noqa: D102
+        self, desc, *, additional_argument_names=None
+    ):
+        if not desc.type.startswith('ros.'):
+            return
+
+        pkg, build_type = get_package_with_build_type(str(desc.path))
+        if not pkg:
+            return
+
         desc.metadata['version'] = pkg.version
 
         # get dependencies
@@ -101,6 +111,9 @@ class RosPackageIdentification(
     def augment_packages(  # noqa: D102
         self, descs, *, additional_argument_names=None
     ):
+        super().augment_packages(
+            descs, additional_argument_names=additional_argument_names)
+
         # get all parsed ROS package manifests
         global _cached_packages
         pkgs = {}


### PR DESCRIPTION
In other colcon packages, the augmentation phase is responsible for adding this information. Two reasons this is a good idea:
1. This information isn't part of a package 'identity'
2. This allows a user to specify the package type in a colcon.pkg file and still get the dependency information parsed correctly.

For example, here's the augmentation logic for `python` packages for reading dependencies: https://github.com/colcon/colcon-core/blob/7b70e61175ab735ea5448ab6e88b4882975566b5/colcon_core/package_augmentation/python.py#L53-L55