### PR TITLE
Add 'origin' metadata to ROS dependencies

### DIFF
--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -111,6 +111,10 @@ class RosPackageIdentification(
             if pkg:
                 pkgs[pkg] = desc
 
+        metadata = {
+            'origin': 'ros',
+        }
+
         # resolve group members and add them to the descriptor dependencies
         for pkg, desc in pkgs.items():
             for group_depend in pkg.group_depends:
@@ -119,8 +123,10 @@ class RosPackageIdentification(
                     continue
                 group_depend.extract_group_members(pkgs)
                 for name in group_depend.members:
-                    desc.dependencies['build'].add(DependencyDescriptor(name))
-                    desc.dependencies['run'].add(DependencyDescriptor(name))
+                    desc.dependencies['build'].add(DependencyDescriptor(
+                        name, metadata=metadata))
+                    desc.dependencies['run'].add(DependencyDescriptor(
+                        name, metadata=metadata))
 
 
 def get_package_with_build_type(path: str):
@@ -176,7 +182,9 @@ def _get_build_type(pkg):
 
 
 def _create_metadata(dependency):
-    metadata = {}
+    metadata = {
+        'origin': 'ros',
+    }
     attributes = (
         'version_lte',
         'version_lt',

--- a/test/test_dependency_metadata.py
+++ b/test/test_dependency_metadata.py
@@ -16,7 +16,7 @@ def test_version_contraint_eq():
     mock.version_eq = '1.1.1'
 
     metadata = _create_metadata(mock)
-    assert len(metadata.keys()) == 1
+    assert len(metadata.keys()) == 2
     assert metadata['version_eq'] == '1.1.1'
 
 
@@ -30,7 +30,7 @@ def test_version_contraint_gt():
     mock.version_gt = '1.1.2'
 
     metadata = _create_metadata(mock)
-    assert len(metadata.keys()) == 1
+    assert len(metadata.keys()) == 2
     assert metadata['version_gt'] == '1.1.2'
 
 
@@ -44,7 +44,7 @@ def test_version_contraint_lt():
     mock.version_lt = '1.1.5'
 
     metadata = _create_metadata(mock)
-    assert len(metadata.keys()) == 1
+    assert len(metadata.keys()) == 2
     assert metadata['version_lt'] == '1.1.5'
 
 
@@ -58,7 +58,7 @@ def test_version_contraint_lte():
     mock.version_lte = '10.1.3'
 
     metadata = _create_metadata(mock)
-    assert len(metadata.keys()) == 1
+    assert len(metadata.keys()) == 2
     assert metadata['version_lte'] == '10.1.3'
 
 
@@ -72,7 +72,7 @@ def test_version_contraint_gte():
     mock.version_gte = '10.45.5'
 
     metadata = _create_metadata(mock)
-    assert len(metadata.keys()) == 1
+    assert len(metadata.keys()) == 2
     assert metadata['version_gte'] == '10.45.5'
 
 
@@ -84,4 +84,4 @@ def test_version_constraint_none():
     mock.version_lte = None
     mock.version_gte = None
     metadata = _create_metadata(mock)
-    assert len(metadata.keys()) == 0
+    assert len(metadata.keys()) == 1


### PR DESCRIPTION
While I don't think we should discriminate between dependency types for general use, this is useful metadata in some contexts and is easy to include.

Follows colcon/colcon-core#564