### PR TITLE
Support upstream catkin_pkg deb

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-ros]
 No-Python2:
-Depends3: python3-catkin-pkg-modules (>= 0.4.14), python3-colcon-cmake (>= 0.2.6), python3-colcon-core (>= 0.7.0), python3-colcon-pkg-config, python3-colcon-python-setup-py (>= 0.2.4), python3-colcon-recursive-crawl
+Depends3: python3-catkin-pkg-modules (>= 0.4.14) | python3-catkin-pkg (>= 0.4.14), python3-colcon-cmake (>= 0.2.6), python3-colcon-core (>= 0.7.0), python3-colcon-pkg-config, python3-colcon-python-setup-py (>= 0.2.4), python3-colcon-recursive-crawl
 Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
The OSRF-provided `python3-catkin-pkg-modules` is still preferred, but we should allow use of the upstream package as well. Either will work fine with `colcon-ros`.

The motivation behind this change is to allow the Package Cloud repository to be usable without the contents of the ROS bootstrap repository, which is where `python3-catkin-pkg-modules` comes from.