### PR TITLE
Add logic for excluding group workaround dependencies

### DIFF
--- a/colcon_ros/package_identification/ros.py
+++ b/colcon_ros/package_identification/ros.py
@@ -176,7 +176,11 @@ def _get_package(path: str):
                 f"'{path}': {e}")
         return None
 
-    pkg.evaluate_conditions(os.environ)
+    condition_context = {
+        **os.environ,
+        'DISABLE_GROUPS_WORKAROUND': '1',
+    }
+    pkg.evaluate_conditions(condition_context)
     return pkg
 
 

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -52,4 +52,5 @@ thomas
 todo
 tuples
 unittest
+workaround
 workspaces


### PR DESCRIPTION
See ros-infrastructure/catkin_pkg#369

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=20943)](http://ci.ros2.org/job/ci_linux/20943/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=15234)](http://ci.ros2.org/job/ci_linux-aarch64/15234/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=21617)](http://ci.ros2.org/job/ci_windows/21617/)