### PR TITLE
Also catch FileNotFoundError when detecting multiarch

### DIFF
--- a/colcon_ros/task/cmake/__init__.py
+++ b/colcon_ros/task/cmake/__init__.py
@@ -44,7 +44,7 @@ def get_multiarch():
     if _multiarch is None:
         try:
             output = subprocess.check_output(['gcc', '-print-multiarch'])
-        except subprocess.CalledProcessError:
+        except (FileNotFoundError, subprocess.CalledProcessError):
             pass
         else:
             _multiarch = output.decode().rstrip()
@@ -52,7 +52,7 @@ def get_multiarch():
             try:
                 output = subprocess.check_output(
                     ['dpkg-architecture', '-qDEB_HOST_MULTIARCH'])
-            except subprocess.CalledProcessError:
+            except (FileNotFoundError, subprocess.CalledProcessError):
                 pass
             else:
                 _multiarch = output.decode().rstrip()


### PR DESCRIPTION
When the executable we're trying to invoke doesn't exist at all, we'll see a `FileNotFoundError` and not a `subprocess.CalledProcessError`.

Fixes #130