### PR TITLE
Improve reusability in colcon_ros.package_identification.ros

### DIFF
--- a/test/test_package_identification_ros.py
+++ b/test/test_package_identification_ros.py
@@ -54,8 +54,7 @@ def test_identify():
 
         augmentation_extension.augment_packages([desc])
         assert desc.metadata['version'] == '0.0.0'
-        # TODO: This is a behavior deviation from colcon-core
-        # assert set(desc.dependencies.keys()) == {'build', 'run', 'test'}
+        assert set(desc.dependencies.keys()) == {'build', 'run', 'test'}
         assert not desc.dependencies['build']
         assert not desc.dependencies['run']
         assert not desc.dependencies['test']


### PR DESCRIPTION
- Expose public functions for performing package augmentation
- Ensure dependency categories are set on descriptors even when those categories are empty (to align with colcon_core)